### PR TITLE
Add basic embedded telemetry simulation

### DIFF
--- a/embedded/rtos/tasks/scheduler.cpp
+++ b/embedded/rtos/tasks/scheduler.cpp
@@ -1,0 +1,85 @@
+#include <vector>
+#include <thread>
+#include <functional>
+#include <chrono>
+#include <atomic>
+#include <string>
+
+/**
+ * Minimal cooperative scheduler used for unit testing and host based
+ * simulation.  It is not a full RTOS replacement but provides an
+ * abstraction that mimics periodic task execution.  Tasks are executed
+ * in their own std::thread and repeat at the user supplied period until
+ * the scheduler is stopped.
+ */
+class Scheduler {
+public:
+    using TaskFn = std::function<void()>;
+
+    struct Task {
+        std::string name;                       ///< Friendly task name
+        TaskFn      fn;                         ///< Function to run
+        std::chrono::milliseconds period{0};    ///< Period between runs
+    };
+
+    ~Scheduler() { stop(); }
+
+    void add_task(Task task) {
+        tasks_.push_back(std::move(task));
+    }
+
+    void start() {
+        if (running_) {
+            return; // already running
+        }
+        running_ = true;
+        for (auto &task : tasks_) {
+            threads_.emplace_back([this, task]() {
+                while (running_) {
+                    auto start_time = std::chrono::steady_clock::now();
+                    task.fn();
+                    auto end_time = std::chrono::steady_clock::now();
+                    auto elapsed =
+                        std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+                    if (elapsed < task.period) {
+                        std::this_thread::sleep_for(task.period - elapsed);
+                    }
+                }
+            });
+        }
+    }
+
+    void stop() {
+        if (!running_) {
+            return;
+        }
+        running_ = false;
+        for (auto &t : threads_) {
+            if (t.joinable()) {
+                t.join();
+            }
+        }
+        threads_.clear();
+    }
+
+private:
+    std::vector<Task> tasks_;
+    std::vector<std::thread> threads_;
+    std::atomic<bool> running_{false};
+};
+
+// Example usage stub demonstrating how the scheduler might be wired
+// into the broader system.  This is not executed in production builds
+// but serves as a reference.
+#ifdef SCHEDULER_DEMO
+#include <iostream>
+int main() {
+    Scheduler sched;
+    sched.add_task({"heartbeat", [](){ std::cout << "tick\n"; }, std::chrono::milliseconds(100)});
+    sched.start();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    sched.stop();
+    return 0;
+}
+#endif
+

--- a/embedded/src/main.cpp
+++ b/embedded/src/main.cpp
@@ -1,0 +1,118 @@
+#include <iostream>
+#include <thread>
+#include <chrono>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <string>
+
+#ifdef __has_include
+#  if __has_include(<nlohmann/json.hpp>)
+#    include <nlohmann/json.hpp>
+#    define HAS_JSON 1
+#  else
+#    define HAS_JSON 0
+#  endif
+#else
+#  define HAS_JSON 0
+#endif
+
+/**
+ * Simple emulation of an embedded flight system.  The goal of this
+ * file is to provide a stand‑alone example that can later be expanded
+ * to make use of FreeRTOS, QEMU, Qt and other technologies listed in the
+ * project roadmap.  For now it demonstrates a minimal producer/consumer
+ * model for telemetry data and a placeholder for AI assisted processing.
+ */
+
+using namespace std::chrono_literals;
+
+struct TelemetryMessage {
+#if HAS_JSON
+    nlohmann::json payload;
+#else
+    std::string payload;
+#endif
+};
+
+class TelemetryQueue {
+public:
+    void push(TelemetryMessage msg) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            queue_.push(std::move(msg));
+        }
+        cv_.notify_one();
+    }
+
+    bool pop(TelemetryMessage &msg) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [&] { return finished_ || !queue_.empty(); });
+        if (queue_.empty()) {
+            return false;
+        }
+        msg = std::move(queue_.front());
+        queue_.pop();
+        return true;
+    }
+
+    void close() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            finished_ = true;
+        }
+        cv_.notify_all();
+    }
+
+private:
+    std::queue<TelemetryMessage> queue_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    bool finished_ = false;
+};
+
+static void sensor_task(TelemetryQueue &q) {
+    for (int i = 0; i < 5; ++i) {
+        TelemetryMessage msg;
+#if HAS_JSON
+        msg.payload = {
+            {"timestamp", i},
+            {"altitude", 1000 + i * 10},
+            {"velocity", 50 + i}
+        };
+#else
+        msg.payload = "tick:" + std::to_string(i);
+#endif
+        q.push(std::move(msg));
+        std::this_thread::sleep_for(100ms);
+    }
+    q.close();
+}
+
+static void ai_task(TelemetryQueue &q) {
+    TelemetryMessage msg;
+    while (q.pop(msg)) {
+#if HAS_JSON
+        std::cout << "AI received telemetry: " << msg.payload.dump() << '\n';
+#else
+        std::cout << "AI received telemetry: " << msg.payload << '\n';
+#endif
+        std::this_thread::sleep_for(150ms);
+    }
+    std::cout << "AI task exiting" << std::endl;
+}
+
+int main() {
+    std::cout << "Starting EmDash Embedded Simulation" << std::endl;
+    TelemetryQueue queue;
+
+    std::thread producer(sensor_task, std::ref(queue));
+    std::thread consumer(ai_task, std::ref(queue));
+
+    producer.join();
+    consumer.join();
+
+    std::cout << "System shutdown" << std::endl;
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- implement simple C++ main demonstrating telemetry producer and AI consumer threads
- optional nlohmann/json usage for structured telemetry
- introduce minimal periodic task scheduler utility

## Testing
- `cd embedded && mkdir -p build && cd build && cmake .. && cmake --build . && ctest` *(No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74a328e68832ea05840056d64046c